### PR TITLE
Feature/batch consume

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -37,3 +37,23 @@ if err != nil {
     panic(err)
 }
 ```
+
+```$golang
+// Consume 5 jobs from the q1, if there's not job availble, wait until 12s passed (polling).
+// If there are some jobs but not enough 5, return jobs as much as possible.
+// And if this consumer fail to ACK any job in 10s, the job can be retried by other consumers.
+jobs, err := c.BatchConsume("q1", 5, 10, 12)
+if err != nil {
+    panic(err)
+}
+
+// Do something with the `job`
+for _, job := range jobs {
+    fmt.Println(string(job.Data))
+    err := c.Ack("q1", job.ID)
+    if err != nil {
+        panic(err)
+    }
+}
+
+```

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -10,6 +10,7 @@ type Engine interface {
 	Publish(namespace, queue string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error)
 	Consume(namespace, queue string, ttrSecond, timeoutSecond uint32) (job Job, err error)
 	ConsumeMulti(namespace string, queues []string, ttrSecond, timeoutSecond uint32) (job Job, err error)
+	BatchConsume(namespace, queue string, count, ttrSecond, timeoutSecond uint32) (jobs []Job, err error)
 	Delete(namespace, queue, jobID string) error
 	Peek(namespace, queue, optionalJobID string) (job Job, err error)
 	Size(namespace, queue string) (size int64, err error)

--- a/engine/migration/engine.go
+++ b/engine/migration/engine.go
@@ -22,6 +22,15 @@ func (e *Engine) Publish(namespace, queue string, body []byte, ttlSecond, delayS
 	return e.newEngine.Publish(namespace, queue, body, ttlSecond, delaySecond, tries)
 }
 
+// BatchConsume consume some jobs of a queue
+func (e *Engine) BatchConsume(namespace, queue string, count, ttrSecond, timeoutSecond uint32) (jobs []engine.Job, err error) {
+	jobs, err = e.oldEngine.BatchConsume(namespace, queue, count, ttrSecond, 0)
+	if len(jobs) != 0 {
+		return // During migration, we always prefer the old engine's data as we need to drain it
+	}
+	return e.newEngine.BatchConsume(namespace, queue, count, ttrSecond, timeoutSecond)
+}
+
 func (e *Engine) Consume(namespace, queue string, ttrSecond, timeoutSecond uint32) (job engine.Job, err error) {
 	job, err = e.oldEngine.Consume(namespace, queue, ttrSecond, 0)
 	if job != nil {


### PR DESCRIPTION
Fixes #17 

批量生成暂时无法做到原子化，如果中间步骤出现故障会造成比较多的垃圾消息或者重复消息。未来考虑使用lua脚本实现。

目前提供阻塞与非阻塞模式的批量消费功能
阻塞模式下的批量消费如果在队列中有任务的情况下，会尽量返回要求数量的任务。如果没有任务则会block住等待第一个任务并返回。